### PR TITLE
General improvements 

### DIFF
--- a/library/Perfdatagraphsprometheus/Client/Prometheus.php
+++ b/library/Perfdatagraphsprometheus/Client/Prometheus.php
@@ -115,14 +115,19 @@ class Prometheus
     }
 
     /**
-     * calculateSteps uses the start and end timestamps to calculate the step parameter
+     * calculateSteps uses the start and end timestamps to calculate the step parameter.
+     *
+     * The step is never smaller than $checkInterval to avoid repeated identical
+     * values caused by Prometheus gap-filling within the lookback window.
      */
-    protected function calculateSteps(int $start, int $end, int $maxDataPoints): string
+    protected function calculateSteps(int $start, int $end, int $maxDataPoints, int $checkInterval = 0): string
     {
         $totalSeconds = $end - $start;
         $stepSeconds = $totalSeconds / $maxDataPoints;
-        // NOTE: This means we can never get a resolution below 60s, even if Icinga2 would send data every 15s
-        $stepSeconds = max($stepSeconds, 60);
+        // Use the check interval as the minimum step so we don't over-sample.
+        // Fall back to 1s when no check interval is available.
+        $minStep = $checkInterval > 0 ? $checkInterval : 1;
+        $stepSeconds = max($stepSeconds, $minStep);
 
         return (int)round($stepSeconds) . 's';
     }

--- a/library/Perfdatagraphsprometheus/Client/Prometheus.php
+++ b/library/Perfdatagraphsprometheus/Client/Prometheus.php
@@ -139,7 +139,8 @@ class Prometheus
         string $from,
         bool $isHostCheck,
         array $includeMetrics,
-        array $excludeMetrics
+        array $excludeMetrics,
+        int $checkInterval = 0
     ): Response {
         $endTime = new DateTimeImmutable();
         $startTime = $endTime->sub(new DateInterval($from));
@@ -150,7 +151,7 @@ class Prometheus
 
         $start = $startTime->getTimestamp();
         $end = $endTime->getTimestamp();
-        $step = $this->calculateSteps($start, $end, $this->maxDataPoints);
+        $step = $this->calculateSteps($start, $end, $this->maxDataPoints, $checkInterval);
 
         $query = [
             'query' => [

--- a/library/Perfdatagraphsprometheus/Client/Transformer.php
+++ b/library/Perfdatagraphsprometheus/Client/Transformer.php
@@ -46,8 +46,8 @@ class Transformer
             $timestamps = [];
 
             foreach ($result['values'] as $point) {
-                $timestamps[] = $point[0];
-                $values[] = $point[1];
+                $timestamps[] = (int) $point[0];
+                $values[] = is_numeric($point[1]) ? (float) $point[1] : null;
             }
 
             $valuesSeries = new PerfdataSeries('value', $values);
@@ -95,11 +95,15 @@ class Transformer
             }
 
             $ts = $dataset->getTimestamps();
-            $valueMap = array_column($result['values'], 1, 0);
-            // Get the matching threshold value for the given timestamp otherwise use null
+            // Build a map of timestamp (int) => float value for fast lookup.
+            $valueMap = [];
+            foreach ($result['values'] as $point) {
+                $valueMap[(int) $point[0]] = is_numeric($point[1]) ? (float) $point[1] : null;
+            }
+            // Align threshold values to the stored timestamps; use null for gaps.
             $thresholds = [];
             foreach ($ts as $timestamp) {
-                $thresholds[] = $valueMap[$timestamp] ?? null;
+                $thresholds[] = $valueMap[(int) $timestamp] ?? null;
             }
 
             $thresholdSeries = new PerfdataSeries($thresholdType, $thresholds);

--- a/library/Perfdatagraphsprometheus/ProvidedHook/Perfdatagraphs/PerfdataSource.php
+++ b/library/Perfdatagraphsprometheus/ProvidedHook/Perfdatagraphs/PerfdataSource.php
@@ -45,7 +45,8 @@ class PerfdataSource extends PerfdataSourceHook
                 $req->getDuration(),
                 $req->isHostCheck(),
                 $req->getIncludeMetrics(),
-                $req->getExcludeMetrics()
+                $req->getExcludeMetrics(),
+                $req->getCheckInterval()
             );
         } catch (ConnectException $e) {
             $perfdataresponse->addError($e->getMessage());


### PR DESCRIPTION
## What

Fix hover tooltip values and graph clipping in the Prometheus backend.

## Why

Prometheus encodes all sample values as JSON strings (e.g. `"4114608128"`). The Transformer stored them as-is, so uPlot received strings instead of numbers and could not populate the hover tooltip or correctly calculate the Y-axis range, causing the top of the graph to be clipped.

The threshold timestamp lookup also used `array_column()` with raw JSON-decoded keys, which caused type mismatches (int vs float) and silently returned `null` for all threshold values — hiding warning and critical lines.

Finally, `calculateSteps()` had a hardcoded 60-second minimum step. This caused repeated identical data points within a single check interval due to Prometheus gap-filling. The step now uses `check_interval` from the `PerfdataRequest` as its minimum.

## Changes

- `Transformer`: cast sample values to `float` (or `null`) and timestamps to `int`
- `Transformer`: replace `array_column()` threshold lookup with explicit int-keyed loop
- `Prometheus`: pass `$checkInterval` through `getMetrics()` to `calculateSteps()`
- `PerfdataSource`: pass `$req->getCheckInterval()` to `getMetrics()`

## Before / After

**Before** — tooltip empty, graph top clipped:

<img width="1545" height="285" alt="image" src="https://github.com/user-attachments/assets/b25388f3-3624-4622-8034-a44393e1183c" />

**After** — tooltip populated, graph fully visible:

<img width="1532" height="265" alt="image" src="https://github.com/user-attachments/assets/b36c3d82-e968-48ee-b798-3e12213a4ac0" />