### PR TITLE
Fix intermittent empty graphs for checks with interval >= query.lookback-delta

### DIFF
--- a/library/Perfdatagraphsprometheus/Client/Prometheus.php
+++ b/library/Perfdatagraphsprometheus/Client/Prometheus.php
@@ -153,6 +153,9 @@ class Prometheus
         $end = $endTime->getTimestamp();
         $step = $this->calculateSteps($start, $end, $this->maxDataPoints, $checkInterval);
 
+        // To avoid issues when a check interval is higher than Prometheus lookback-delta
+        $q = sprintf('last_over_time(%s[%s])', $q, $step);
+
         $query = [
             'query' => [
                 'query' => $q,


### PR DESCRIPTION
### What
Wrap the `query_range` selector in `last_over_time(<selector>[<step>])` in `Prometheus::getMetrics()`.

### Why
Fixes #15. The backend queries a raw instant-vector selector at `step = check_interval`. In a `query_range`, Prometheus only yields a value at a step timestamp when a sample exists within `query.lookback-delta` (default 5m) before it. When `check_interval >= lookback-delta`, the step grid and the sample grid share the same spacing but an arbitrary phase offset, so every step can land in the gap after a sample's lookback window and the **whole range returns empty** — surfacing as "No data received" that flips to rendered on refresh (the range end moves and shifts the phase) or after a forced check. Frequent checks (interval < lookback) are unaffected.

### How
`last_over_time(<selector>[<step>])` returns the most recent sample in each step bucket. `calculateSteps()` already guarantees `step >= check_interval`, so every bucket contains a sample and the result is stable regardless of grid alignment. It also removes the gap-filling staircase that the step clamp was introduced to avoid, and preserves `__name__`/labels so the `Transformer` (which switches on `state_check_perfdata` / `state_check_threshold`) is unaffected.

### Verification
On a 10-minute check, sweeping the `query_range` end across one interval and counting returned points:

```text
raw selector,                  step=600s -> 4, 6, 7, 3, 2, 0, 5   (0 = empty graph)
last_over_time(selector[10m]), step=600s -> 7, 7, 7, 7, 7, 7, 7
```

The raw query drops to zero at certain phases; the wrapped query is stable.